### PR TITLE
Update footer CSS for columns

### DIFF
--- a/css/footerStyle.css
+++ b/css/footerStyle.css
@@ -10,11 +10,47 @@
   padding: 1.5em 0 0.5em 0;
 }
 
+/* Legacy pages use .footer-links instead of .footer-container */
+.footer-links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 3em;
+  width: 100%;
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 1.5em 0 0.5em 0;
+}
+
 .footer-col {
   flex: 1 1 200px;
   min-width: 200px;
   color: #fff;
   text-align: left;
+}
+
+/* Columns when using .footer-links */
+.footer-links ul {
+  padding: 0;
+  margin: 0 0 0.5em 0;
+  list-style: none;
+  flex: 1 1 200px;
+  min-width: 200px;
+  color: #fff;
+  text-align: left;
+}
+
+.footer-links li {
+  display: block;
+  padding: 0.2em 0;
+  font-size: 1em;
+}
+
+.footer-links p {
+  font-size: 1.1em;
+  font-weight: bold;
+  margin-bottom: 0.4em;
 }
 
 .footer-col ul {
@@ -64,5 +100,5 @@ footer {
   padding: 0 0 1em 0;
   min-height: 120px; /* adjust as needed */
   box-sizing: border-box;
-  border-top: 2px solid #222;
+  border-top: none;
 }


### PR DESCRIPTION
## Summary
- support legacy `.footer-links` container with flexbox layout
- remove top border from footer to drop dashed line

## Testing
- `pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6843151955808324bbc1281b3c1315aa