### PR TITLE
Add Tigers Gym page

### DIFF
--- a/familyMan/index.html
+++ b/familyMan/index.html
@@ -59,6 +59,7 @@
                             <li class="nav-item"><a href="../pioneer/index.html" class="nav-item">Pioneer</a></li>
                             <li class="nav-item"><a href="../founder/index.html" class="nav-item">Founder</a></li>
                             <li class="nav-item"><a href="../entrepreneur/index.html">Entrepreneur</a></li>
+                            <li class="nav-item"><a href="../tigersGym/index.html" class="nav-item">Tigers Gym</a></li>
                             <li class="nav-item"><a href="../media/mediaTVmenu1.html" class="nav-item">Media Coverage</a>
                             </li>
                         </ul>

--- a/founder/index.html
+++ b/founder/index.html
@@ -59,6 +59,7 @@
                             <li class="nav-item"><a href="../pioneer/index.html" class="nav-item">Pioneer</a></li>
                             <li class="nav-item disabled"><a href="#" class="nav-item">Founder</a></li>
                             <li class="nav-item"><a href="../entrepreneur/index.html">Entrepreneur</a></li>
+                            <li class="nav-item"><a href="../tigersGym/index.html" class="nav-item">Tigers Gym</a></li>
                             <li class="nav-item"><a href="../media/mediaTVmenu1.html" class="nav-item">Media Coverage</a>
                             </li>
                         </ul>

--- a/index.html
+++ b/index.html
@@ -59,6 +59,7 @@
                             <li class="nav-item"><a href="pioneer/index.html" class="nav-item">Pioneer</a></li>
                             <li class="nav-item"><a href="founder/index.html" class="nav-item">Founder</a></li>
                             <li class="nav-item"><a href="entrepreneur/index.html" class="nav-item">Entrepreneur</a></li>
+                            <li class="nav-item"><a href="tigersGym/index.html" class="nav-item">Tigers Gym</a></li>
                             <li class="nav-item"><a href="media/mediaTVmenu1.html" class="nav-item">Media Coverage</a></li>
                         </ul>
                     </div>

--- a/manOfGod/index.html
+++ b/manOfGod/index.html
@@ -59,6 +59,7 @@
                             <li class="nav-item"><a href="../pioneer/index.html" class="nav-item">Pioneer</a></li>
                             <li class="nav-item"><a href="../founder/index.html" class="nav-item">Founder</a></li>
                             <li class="nav-item"><a href="../entrepreneur/index.html">Entrepreneur</a></li>
+                            <li class="nav-item"><a href="../tigersGym/index.html" class="nav-item">Tigers Gym</a></li>
                             <li class="nav-item"><a href="../media/mediaTVmenu1.html" class="nav-item">Media Coverage</a>
                             </li>
                         </ul>

--- a/martialArtist/index.html
+++ b/martialArtist/index.html
@@ -59,6 +59,7 @@
                             <li class="nav-item"><a href="../pioneer/index.html" class="nav-item">Pioneer</a></li>
                             <li class="nav-item"><a href="../founder/index.html" class="nav-item">Founder</a></li>
                             <li class="nav-item"><a href="../entrepreneur/index.html">Entrepreneur</a></li>
+                            <li class="nav-item"><a href="../tigersGym/index.html" class="nav-item">Tigers Gym</a></li>
                             <li class="nav-item"><a href="../media/mediaTVmenu1.html" class="nav-item">Media Coverage</a>
                             </li>
                         </ul>

--- a/media/mediaTVmenu1.html
+++ b/media/mediaTVmenu1.html
@@ -59,6 +59,7 @@
                             <li class="nav-item"><a href="../pioneer/index.html" class="nav-item">Pioneer</a></li>
                             <li class="nav-item"><a href="../founder/index.html" class="nav-item">Founder</a></li>
                             <li class="nav-item"><a href="../entrepreneur/index.html">Entrepreneur</a></li>
+                            <li class="nav-item"><a href="../tigersGym/index.html" class="nav-item">Tigers Gym</a></li>
                             <li class="nav-item"><a href="../media/mediaTVmenu1.html" class="nav-item">Media
                                     Coverage</a>
                             </li>

--- a/media/mediaTVmenu2.html
+++ b/media/mediaTVmenu2.html
@@ -59,6 +59,7 @@
                             <li class="nav-item"><a href="../pioneer/index.html" class="nav-item">Pioneer</a></li>
                             <li class="nav-item"><a href="../founder/index.html" class="nav-item">Founder</a></li>
                             <li class="nav-item"><a href="../entrepreneur/index.html">Entrepreneur</a></li>
+                            <li class="nav-item"><a href="../tigersGym/index.html" class="nav-item">Tigers Gym</a></li>
                             <li class="nav-item"><a href="../media/mediaTVmenu1.html" class="nav-item">Media
                                     Coverage</a>
                             </li>

--- a/media/mediaTVmenu3.html
+++ b/media/mediaTVmenu3.html
@@ -58,6 +58,7 @@
                             <li class="nav-item"><a href="../pioneer/index.html" class="nav-item">Pioneer</a></li>
                             <li class="nav-item"><a href="../founder/index.html" class="nav-item">Founder</a></li>
                             <li class="nav-item"><a href="../entrepreneur/index.html">Entrepreneur</a></li>
+                            <li class="nav-item"><a href="../tigersGym/index.html" class="nav-item">Tigers Gym</a></li>
                             <li class="nav-item"><a href="../media/mediaTVmenu1.html" class="nav-item">Media
                                     Coverage</a>
                             </li>

--- a/media/mediaTVmenu7.html
+++ b/media/mediaTVmenu7.html
@@ -58,6 +58,7 @@
                             <li class="nav-item"><a href="../pioneer/index.html" class="nav-item">Pioneer</a></li>
                             <li class="nav-item"><a href="../founder/index.html" class="nav-item">Founder</a></li>
                             <li class="nav-item"><a href="../entrepreneur/index.html">Entrepreneur</a></li>
+                            <li class="nav-item"><a href="../tigersGym/index.html" class="nav-item">Tigers Gym</a></li>
                             <li class="nav-item"><a href="../media/mediaTVmenu1.html" class="nav-item">Media
                                     Coverage</a>
                             </li>

--- a/tigersGym/content.txt
+++ b/tigersGym/content.txt
@@ -1,0 +1,11 @@
+Tigers Gym & Fight Club
+
+Tigers Gym is owned and operated by Coach Dan Isaac, former undefeated world champion kickboxer (1993-1995), and Coach Tanya Isaac, a Fitness, Strength and Nutrition specialist. We focus on personal training and group classes for adults, and we have a weekly Youth boxing program. Our assistant coaches include Coach Tony, our Youth boxing Coach, and Honorary Coach Jayden, our fight team Coach.
+
+We offer daily group classes with a new combat discipline each evening. We also offer daily personal training classes that are tailored to your specific training goals. All group classes are 45 minutes or more, and all personal training sessions are 30 minutes or more.
+
+We are a USA Boxing registered gym (the national sanctioning body for amateur boxing), and we are also registered with GAMMAF and WCK. Our boxers, kickboxers, and MMA fighters regularly compete on the local circuit.
+
+We offer a per-class payment option, class packs to bundle your classes and save money, or monthly membership plans. If you are interested in training with us, the first step is to call or text to schedule an in-person appointment at Tigers Gym. For more information, text Coach Dan at 314-203-6068 or email tigersgym@gmail.com.
+
+Apart from our classes and training programs, Tigers Gym is a community with a mission to support and empower our city through martial arts and fellowship. We offer a weekly Bible Study for all those interested.

--- a/tigersGym/index.html
+++ b/tigersGym/index.html
@@ -12,7 +12,7 @@
     <link rel="stylesheet" href="../css/customStyle.css">
     <link rel="stylesheet" href="../css/footerStyle.css">
 
-    <title>Dan Isaac - Pioneer</title>
+    <title>Dan Isaac - Tigers Gym</title>
 </head>
 
 <body class="d-flex flex-column min-vh-100">
@@ -56,10 +56,10 @@
                             <li class="nav-item"><a href="../manOfGod/index.html" class="nav-item">Man Of God</a></li>
                             <li class="nav-item"><a href="../martialArtist/index.html" class="nav-item">Martial
                                     Artist</a></li>
-                            <li class="nav-item disabled"><a href="#" class="nav-item">Pioneer</a></li>
+                            <li class="nav-item"><a href="../pioneer/index.html" class="nav-item">Pioneer</a></li>
                             <li class="nav-item"><a href="../founder/index.html" class="nav-item">Founder</a></li>
                             <li class="nav-item"><a href="../entrepreneur/index.html">Entrepreneur</a></li>
-                            <li class="nav-item"><a href="../tigersGym/index.html" class="nav-item">Tigers Gym</a></li>
+                            <li class="nav-item disabled"><a href="#" class="nav-item">Tigers Gym</a></li>
                             <li class="nav-item"><a href="../media/mediaTVmenu1.html" class="nav-item">Media Coverage</a>
                             </li>
                         </ul>
@@ -69,26 +69,17 @@
             <!-- TV Content Area -->
             <div id="topTV" class="tvcontainer container">
                 <img class="tv img-fluid mx-auto" src="../images/coachdan_TV.png" alt="Transparent TV for video">
-                <iframe src="https://www.youtube.com/embed/inAv3MkzNS0" frameborder="0" allowfullscreen></iframe>
+                <iframe src="https://www.youtube.com/embed/lnmRA-4q0SY" frameborder="0" allowfullscreen></iframe>
             </div>
             <!-- Main Content Area -->
             <div class="container-fluid">
                 <div id="greyContent" class="row">
                     <div class="col">
-                        <p class="text-wrap mx-auto d-block">Dan Isaac is widely regarded as the original forerunner and pioneer for Mixed Martial Arts 
-                            in India: he founded India's first ever mma training center for amateur and professional mma fighters in 1998, he 
-                            hosted and organized International amateur and professional mma shows when these were non-existent in the country.
-                        </p>
-                        <img class="img-fluid mx-auto d-block pioneer-image" src="../images/pioneerPic.png" alt="Image of Dan Isaac">
-                        <p class="text-wrap mx-auto d-block">He travelled across the country providing training, education and information about MMA to 
-                            Indian martial artists through seminars and workshops and this work laid the foundations for the sport becoming main-stream 
-                            in India two decades later. His seminars entitled "The Business of MMA" has helped numerous martial arts Instructors to 
-                            make the transition from traditional martial arts schools to MMA gyms.
-                        </p>
-                        <p class="text-wrap mx-auto d-block">Dan was the prime focus of India's first MMA documentary film entitled "MMA India: Fighting for a dream" 
-                            available on YouTube. Between 2012 and 2015 Dan was first the COO and then the CEO of India's first mainstream MMA promotion 
-                            'Super Fight League' led by Sanjay Dutt and Raj Kundra.
-                        </p>
+                        <p class="text-wrap mx-auto d-block">Tigers Gym is owned and operated by Coach Dan Isaac, former undefeated world champion kickboxer (1993-1995), and Coach Tanya Isaac, a Fitness, Strength and Nutrition specialist. We focus on personal training and group classes for adults, and we have a weekly Youth boxing program. Our assistant coaches include Coach Tony, our Youth boxing Coach, and Honorary Coach Jayden, our fight team Coach.</p>
+                        <p class="text-wrap mx-auto d-block">We offer daily group classes with a new combat discipline each evening. We also offer daily personal training classes that are tailored to your specific training goals. All group classes are 45 minutes or more, and all personal training sessions are 30 minutes or more.</p>
+                        <p class="text-wrap mx-auto d-block">We are a USA Boxing registered gym (the national sanctioning body for amateur boxing), and we are also registered with GAMMAF and WCK. Our boxers, kickboxers, and MMA fighters regularly compete on the local circuit.</p>
+                        <p class="text-wrap mx-auto d-block">We offer a per-class payment option, class packs to bundle your classes and save money, or monthly membership plans. If you are interested in training with us, the first step is to call or text to schedule an in-person appointment at Tigers Gym. For more information, text Coach Dan at 314-203-6068 or email tigersgym@gmail.com.</p>
+                        <p class="text-wrap mx-auto d-block">Apart from our classes and training programs, Tigers Gym is a community with a mission to support and empower our city through martial arts and fellowship. We offer a weekly Bible Study for all those interested.</p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- add new Tigers Gym webpage with contact and training info
- include Tigers Gym in site navigation across all pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687c100f94b48324b3f5b403b6636164