### PR TITLE
Fix Tigers Gym menu link and page header

### DIFF
--- a/entrepreneur/index.html
+++ b/entrepreneur/index.html
@@ -59,6 +59,7 @@
                             <li class="nav-item"><a href="../pioneer/index.html" class="nav-item">Pioneer</a></li>
                             <li class="nav-item"><a href="../founder/index.html" class="nav-item">Founder</a></li>
                             <li class="nav-item disabled"><a href="#">Entrepreneur</a></li>
+                            <li class="nav-item"><a href="../tigersGym/index.html" class="nav-item">Tigers Gym</a></li>
                             <li class="nav-item"><a href="../media/mediaTVmenu1.html" class="nav-item">Media Coverage</a>
                             </li>
                         </ul>

--- a/tigersGym/index.html
+++ b/tigersGym/index.html
@@ -71,6 +71,7 @@
                 <img class="tv img-fluid mx-auto" src="../images/coachdan_TV.png" alt="Transparent TV for video">
                 <iframe src="https://www.youtube.com/embed/KNdUk4bgEd0?si=RPmfaJXdkV6h65ni" frameborder="0" allowfullscreen></iframe>
             </div>
+            <h1 class="display-4 text-center font-weight-bold my-4">Tigers Gym &amp; Fight Club</h1>
             <!-- Main Content Area -->
             <div class="container-fluid">
                 <div id="greyContent" class="row">
@@ -78,7 +79,7 @@
                         <p class="text-wrap mx-auto d-block">Tigers Gym is owned and operated by Coach Dan Isaac, former undefeated world champion kickboxer (1993-1995), and Coach Tanya Isaac, a Fitness, Strength and Nutrition specialist. We focus on personal training and group classes for adults, and we have a weekly Youth boxing program. Our assistant coaches include Coach Tony, our Youth boxing Coach, and Honorary Coach Jayden, our fight team Coach.</p>
                         <p class="text-wrap mx-auto d-block">We offer daily group classes with a new combat discipline each evening. We also offer daily personal training classes that are tailored to your specific training goals. All group classes are 45 minutes or more, and all personal training sessions are 30 minutes or more.</p>
                         <p class="text-wrap mx-auto d-block">We are a USA Boxing registered gym (the national sanctioning body for amateur boxing), and we are also registered with GAMMAF and WCK. Our boxers, kickboxers, and MMA fighters regularly compete on the local circuit.</p>
-                        <p class="text-wrap mx-auto d-block">We offer a per-class payment option, class packs to bundle your classes and save money, or monthly membership plans. If you are interested in training with us, the first step is to call or text to schedule an in-person appointment at Tigers Gym. For more information, text Coach Dan at 314-203-6068 or email tigersgym@gmail.com.</p>
+                        <p class="text-wrap mx-auto d-block">We offer a per-class payment option, class packs to bundle your classes and save money, or monthly membership plans. If you are interested in training with us, the first step is to call or text to schedule an in-person appointment at Tigers Gym. For more information, text Coach Dan at <a href="tel:3142036068">314-203-6068</a> or email <a href="mailto:tigersgym@gmail.com">tigersgym@gmail.com</a>.</p>
                         <p class="text-wrap mx-auto d-block">Apart from our classes and training programs, Tigers Gym is a community with a mission to support and empower our city through martial arts and fellowship. We offer a weekly Bible Study for all those interested.</p>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- add Tigers Gym menu item on the Entrepreneur page
- highlight Tigers Gym & Fight Club title on its page
- make phone number and email clickable

## Testing
- `grep -n "tel:" -n | head`

------
https://chatgpt.com/codex/tasks/task_e_687c1acb1a948324be04333a0a777f14