### PR TITLE
Improve SEO metadata and header position

### DIFF
--- a/entrepreneur/index.html
+++ b/entrepreneur/index.html
@@ -12,7 +12,8 @@
     <link rel="stylesheet" href="../css/customStyle.css">
     <link rel="stylesheet" href="../css/footerStyle.css">
     
-    <title>Dan Isaac - Entrepreneur</title>
+    <title>Dan Isaac | Martial Arts Entrepreneur & Coach</title>
+    <meta name="description" content="Explore Dan Isaac's entrepreneurial ventures promoting fighters and consulting for MMA organizations while teaching self-defense around the world.">
 </head>
 
 <body class="d-flex flex-column min-vh-100">

--- a/familyMan/index.html
+++ b/familyMan/index.html
@@ -12,7 +12,8 @@
     <link rel="stylesheet" href="../css/customStyle.css">
     <link rel="stylesheet" href="../css/footerStyle.css">
 
-    <title>Dan Isaac - Family Man</title>
+    <title>Coach Dan Isaac | Devoted Husband and Family Man</title>
+    <meta name="description" content="Learn about Dan Isaac's life as a husband and father. View family photos and see how his loved ones inspire everything he does.">
 </head>
 
 <body class="d-flex flex-column">

--- a/founder/index.html
+++ b/founder/index.html
@@ -12,7 +12,8 @@
     <link rel="stylesheet" href="../css/customStyle.css">
     <link rel="stylesheet" href="../css/footerStyle.css">
 
-    <title>Dan Isaac - Founder</title>
+    <title>Dan Isaac | Founder of Tigers Gym and Sport MMA</title>
+    <meta name="description" content="Read about Dan Isaac's founding of Tigers Gym & Fight Club, the World Council of Kickboxing and Sport MMA programs empowering fighters worldwide.">
 </head>
 
 <body class="d-flex flex-column min-vh-100">

--- a/index-comingsoon.html
+++ b/index-comingsoon.html
@@ -7,7 +7,8 @@
     <link rel="stylesheet" href="css/styles_flexbox.css" />
     <link rel="shortcut icon" href="danfavicon.ico?v=2" type="image/x-icon" />
     <link rel="apple-touch-icon" href="favicon.ico" type="image/x-icon" />
-    <title>Dan Isaac - Coming Soon</title>
+    <title>Coach Dan Isaac | Website Coming Soon</title>
+    <meta name="description" content="A new site featuring martial arts champion and coach Dan Isaac is on the way. Check back soon for updates.">
   </head>
   <body>
     <!-- <div class="content">

--- a/index.html
+++ b/index.html
@@ -14,7 +14,8 @@
     <link rel="stylesheet" href="/css/style.css">
     <link rel="stylesheet" href="../css/footerStyle.css">
 
-    <title>Dan Isaac</title>
+    <title>Coach Dan Isaac | Martial Artist, Pastor & Mentor</title>
+    <meta name="description" content="Official site of Coach Dan Isaac — world champion martial artist, pastor and mentor based in St Louis. Explore his journey and connect with Tigers Gym.">
 </head>
 
 <body class="d-flex flex-column">

--- a/index_flexbox.html
+++ b/index_flexbox.html
@@ -3,7 +3,8 @@
 <html>
 <head>
     <meta charset="utf-8" />
-    <title>Coach Dan Isaac</title>
+    <title>Coach Dan Isaac | Flexbox Layout Demo</title>
+    <meta name="description" content="Testing layout concepts for the official Coach Dan Isaac website using CSS Flexbox.">
     <link rel="stylesheet" href="css/styles_flexbox.css">
     
 </head>

--- a/manOfGod/index.html
+++ b/manOfGod/index.html
@@ -12,7 +12,8 @@
     <link rel="stylesheet" href="../css/customStyle.css">
     <link rel="stylesheet" href="../css/footerStyle.css">
 
-    <title>Dan Isaac - Man of God</title>
+    <title>Pastor Dan Isaac | Sharing Faith and Ministry Worldwide</title>
+    <meta name="description" content="Discover how Pastor Dan Isaac's miraculous testimony fuels his mission to share the Gospel. Follow his teachings and weekly live ministry.">
 </head>
 
 <body class="d-flex flex-column min-vh-100">

--- a/martialArtist/index.html
+++ b/martialArtist/index.html
@@ -12,7 +12,8 @@
     <link rel="stylesheet" href="../css/customStyle.css">
     <link rel="stylesheet" href="../css/footerStyle.css">
 
-    <title>Dan Isaac - Martial Artist</title>
+    <title>Dan Isaac | World Champion Martial Artist & Coach</title>
+    <meta name="description" content="From winning international titles to founding Tigers Gym USA, Dan Isaac trains fighters across the globe with decades of martial arts expertise.">
 </head>
 
 <body class="d-flex flex-column min-vh-100">

--- a/pioneer/index.html
+++ b/pioneer/index.html
@@ -12,7 +12,8 @@
     <link rel="stylesheet" href="../css/customStyle.css">
     <link rel="stylesheet" href="../css/footerStyle.css">
 
-    <title>Dan Isaac - Pioneer</title>
+    <title>Dan Isaac | The Pioneer Who Brought MMA to India</title>
+    <meta name="description" content="Trace Dan Isaac's pioneering efforts that introduced Mixed Martial Arts to India, from opening the first training center to promoting global events.">
 </head>
 
 <body class="d-flex flex-column min-vh-100">

--- a/tigersGym/index.html
+++ b/tigersGym/index.html
@@ -12,7 +12,8 @@
     <link rel="stylesheet" href="../css/customStyle.css">
     <link rel="stylesheet" href="../css/footerStyle.css">
 
-    <title>Dan Isaac - Tigers Gym</title>
+    <title>Tigers Gym &amp; Fight Club St Louis | Coach Dan Isaac</title>
+    <meta name="description" content="Train with Coach Dan Isaac at Tigers Gym & Fight Club in St Louis, Missouri. Join group classes, personal training and youth boxing in a welcoming community.">
 </head>
 
 <body class="d-flex flex-column min-vh-100">
@@ -71,11 +72,11 @@
                 <img class="tv img-fluid mx-auto" src="../images/coachdan_TV.png" alt="Transparent TV for video">
                 <iframe src="https://www.youtube.com/embed/KNdUk4bgEd0?si=RPmfaJXdkV6h65ni" frameborder="0" allowfullscreen></iframe>
             </div>
-            <h1 class="display-4 text-center font-weight-bold my-4">Tigers Gym &amp; Fight Club</h1>
             <!-- Main Content Area -->
             <div class="container-fluid">
                 <div id="greyContent" class="row">
                     <div class="col">
+                        <h1 class="display-4 text-center font-weight-bold my-4">Tigers Gym &amp; Fight Club</h1>
                         <p class="text-wrap mx-auto d-block">Tigers Gym is owned and operated by Coach Dan Isaac, former undefeated world champion kickboxer (1993-1995), and Coach Tanya Isaac, a Fitness, Strength and Nutrition specialist. We focus on personal training and group classes for adults, and we have a weekly Youth boxing program. Our assistant coaches include Coach Tony, our Youth boxing Coach, and Honorary Coach Jayden, our fight team Coach.</p>
                         <p class="text-wrap mx-auto d-block">We offer daily group classes with a new combat discipline each evening. We also offer daily personal training classes that are tailored to your specific training goals. All group classes are 45 minutes or more, and all personal training sessions are 30 minutes or more.</p>
                         <p class="text-wrap mx-auto d-block">We are a USA Boxing registered gym (the national sanctioning body for amateur boxing), and we are also registered with GAMMAF and WCK. Our boxers, kickboxers, and MMA fighters regularly compete on the local circuit.</p>


### PR DESCRIPTION
## Summary
- add meta descriptions and new titles to all pages
- move Tigers Gym heading inside the main content section for better structure

## Testing
- `grep -r "<meta name=\"description\"" -n | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_687c1e084fd88324a759829e72212ecb