### PR TITLE
Update Tigers Gym heading and spacing

### DIFF
--- a/tigersGym/index.html
+++ b/tigersGym/index.html
@@ -83,7 +83,7 @@
             </div>
             <!-- Main Content Area -->
             <div class="container-fluid">
-                <div id="greyContent" class="row">
+                <div id="greyContent" class="row" style="margin-top: 7em;">
                     <div class="col">
                         <h1 class="display-4 text-center font-weight-bold my-4">Tigers Gym &amp; Fight Club</h1>
                         <p class="text-wrap mx-auto d-block">Tigers Gym is owned and operated by Coach Dan Isaac, former undefeated world champion kickboxer (1993-1995), and Coach Tanya Isaac, a Fitness, Strength and Nutrition specialist. We focus on personal training and group classes for adults, and we have a weekly Youth boxing program. Our assistant coaches include Coach Tony, our Youth boxing Coach, and Honorary Coach Jayden, our fight team Coach.</p>
@@ -97,8 +97,8 @@
             </div>
 
             <!-- Photo Gallery -->
-            <section id="photo-gallery" class="container my-4">
-                <h2 class="text-center font-weight-bold mb-3">Gym Photos</h2>
+            <section id="photo-gallery" class="container my-4" style="margin-top: 4em;">
+                <h2 class="text-center font-weight-bold mb-3">Who We Are</h2>
                 <div class="row justify-content-center">
                     <div class="col-6 col-md-4 col-lg-3 mb-3" >
                         <img src="../images/tigersgym/tigersgym_fightclub_01.webp" class="img-thumbnail gallery-thumb" data-index="0" alt="Gym photo 1">


### PR DESCRIPTION
## Summary
- tweak Tigers Gym page heading to "Who We Are"
- add top margin to the main section and photos

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687c50464d38832487e07bbcfc9565ec