### PR TITLE
Improve mobile footer spacing

### DIFF
--- a/css/footerStyle.css
+++ b/css/footerStyle.css
@@ -91,23 +91,30 @@
     flex-direction: column;
     align-items: flex-start;
     justify-content: flex-start;
-    gap: 0.5em;
-    padding: calc(1em + 10px) 0 35px 35px;
+    gap: 0.25em;
+    padding: 0.5em 1em;
   }
   .footer-links {
     flex-direction: column;
     align-items: flex-start;
     justify-content: flex-start;
-    gap: 0.5em;
-    padding: 1em 0 35px 35px;
+    gap: 0.25em;
+    padding: 0.5em 1em;
   }
   .footer-col {
     text-align: left;
     flex: 1 1 auto;
     min-width: 0;
   }
+  .footer-col ul {
+    margin: 0 0 0.25em 0;
+  }
+  .footer-col p {
+    margin-bottom: 0.2em;
+  }
   footer {
-    min-height: 60px;
+    min-height: 50px;
+    padding-bottom: 0.5em;
   }
 }
 


### PR DESCRIPTION
## Summary
- tighten mobile footer spacing for `.footer-container` and `.footer-links`
- reduce padding and gap to minimize empty space
- tweak footer element height and margins for small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687c65670aa48324bafa07cb88b10643