### PR TITLE
Add more spacing after gallery heading

### DIFF
--- a/tigersGym/index.html
+++ b/tigersGym/index.html
@@ -101,7 +101,7 @@
 
             <!-- Photo Gallery -->
             <section id="photo-gallery" class="container my-4" style="margin-top: 4em;">
-                <h2 class="text-center font-weight-bold mb-3">Who We Are</h2>
+                <h2 class="text-center font-weight-bold mb-5">Who We Are</h2>
                 <div class="row justify-content-center">
                     <div class="col-6 col-md-4 col-lg-3 mb-3" >
                         <img src="../images/tigersgym/tigersgym_fightclub_01.webp" class="img-thumbnail gallery-thumb" data-index="0" alt="Gym photo 1">


### PR DESCRIPTION
## Summary
- tweak Tigers Gym photo gallery heading spacing so images are further below

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687edb542f58832484eeae63b4b45597