### PR TITLE
Fix Tigers Gym nav on thank-you page

### DIFF
--- a/tigersGym/thank-you.html
+++ b/tigersGym/thank-you.html
@@ -56,7 +56,7 @@
               <li class="nav-item"><a href="../pioneer/index.html" class="nav-item">Pioneer</a></li>
               <li class="nav-item"><a href="../founder/index.html" class="nav-item">Founder</a></li>
               <li class="nav-item"><a href="../entrepreneur/index.html" class="nav-item">Entrepreneur</a></li>
-              <li class="nav-item disabled"><a href="#" class="nav-item">Tigers Gym</a></li>
+              <li class="nav-item"><a href="index.html" class="nav-item">Tigers Gym</a></li>
               <li class="nav-item"><a href="../media/mediaTVmenu1.html" class="nav-item">Media Coverage</a></li>
             </ul>
           </div>


### PR DESCRIPTION
## Summary
- enable Tigers Gym menu link on the thank-you page

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_687f02c632c48324b055c786393cdb90