### PR TITLE
Reduce Clear Path footer attribution size

### DIFF
--- a/css/footerStyle.css
+++ b/css/footerStyle.css
@@ -81,7 +81,8 @@
 .footer-copyright {
   text-align: center;
   margin: 1em 0 0.5em 0;
-  font-size: 1em;
+  font-size: 12px;
+  font-weight: normal;
   color: #fff;
 }
 


### PR DESCRIPTION
## Summary
- Shrink "Developed and maintained by Clear Path Solutions LLC" footer attribution to a 12px normal-weight style so it aligns with other footer text.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a31c68a6c8324a3abd9d357c88d5f